### PR TITLE
PerformNotificationActionRequest

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -4,6 +4,7 @@
 //! there are a wide variety of Attributes that can be used. Please see the attributes module
 //! provided by this library for which attributes are valid when working with ANCS.
 //! 
+pub mod action;
 pub mod app;
 pub mod category;
 pub mod command;

--- a/src/attributes/action.rs
+++ b/src/attributes/action.rs
@@ -1,0 +1,75 @@
+use nom::{error::ParseError, number::complete::le_u8, IResult};
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ActionID {
+    Positive = 0,
+    Negative = 1,
+}
+
+impl From<ActionID> for u8 {
+    /// Convert a `ActionID` to a `u8`:
+    ///
+    /// # Examples
+    /// ```
+    /// # use ancs::attributes::action::ActionID;
+    /// let data: u8 = ActionID::Positive.into();
+    ///
+    /// assert_eq!(0, data);
+    /// ```
+    fn from(original: ActionID) -> u8 {
+        match original {
+            ActionID::Positive => 0,
+            ActionID::Negative => 1,
+        }
+    }
+}
+
+impl TryFrom<u8> for ActionID {
+    type Error = ActionIDError;
+
+    /// Attempts to convert a `u8` to a `ActionID`
+    ///
+    /// # Examples
+    /// ```
+    /// # use ancs::attributes::action::ActionID;
+    /// let action_id: ActionID = ActionID::try_from(0).unwrap();
+    ///
+    /// assert_eq!(ActionID::Positive, action_id);
+    /// ```
+    ///
+    fn try_from(original: u8) -> Result<Self, Self::Error> {
+        match original {
+            0 => Ok(ActionID::Positive),
+            1 => Ok(ActionID::Negative),
+            _ => Err(ActionIDError),
+        }
+    }
+}
+
+impl ActionID {
+    /// Attempts to parse a `ActionID` from a `&[u8]`
+    ///
+    /// # Examples
+    /// ```
+    /// # use ancs::attributes::action::ActionID;
+    /// let data: [u8; 2] = [0, 1];
+    /// let (data, action_id) = ActionID::parse(&data).unwrap();
+    ///
+    /// assert_eq!(ActionID::Positive, action_id);
+    /// ```
+    ///
+    pub fn parse(i: &[u8]) -> IResult<&[u8], ActionID> {
+        let (i, action_id) = le_u8(i)?;
+
+        match ActionID::try_from(action_id) {
+            Ok(action_id) => Ok((i, action_id)),
+            Err(_) => Err(nom::Err::Failure(ParseError::from_error_kind(
+                i,
+                nom::error::ErrorKind::Fail,
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ActionIDError;


### PR DESCRIPTION
This adds support for the [Perform Notification Action command](https://developer.apple.com/library/archive/documentation/CoreBluetooth/Reference/AppleNotificationCenterServiceSpecification/Specification/Specification.html#//apple_ref/doc/uid/TP40013460-CH1-SW61), and the required ActionID enum.

(There are other changes that I made, to [fix protocol compatibility](https://github.com/ianmarmour/ancs/compare/main...impiaaa:ancs:event-flags-bitfield) or [for convenience](https://github.com/ianmarmour/ancs/compare/main...impiaaa:ancs:uuid), but I held off from a PR because they would break API compatibility.)